### PR TITLE
Add copy buttons to sensitivity analysis sections

### DIFF
--- a/src/components/analysis/sensitivity/SensitivitySummary.tsx
+++ b/src/components/analysis/sensitivity/SensitivitySummary.tsx
@@ -1,5 +1,9 @@
+import { useState } from "react";
 import { DataPanel } from "@/components/ui/DataPanel";
 import { AnalysisVariable } from "../VariableControl";
+import { Button } from "@/components/ui/button";
+import { Copy, Check } from "lucide-react";
+import { useToast } from "@/components/ui/use-toast";
 
 interface SensitivitySummaryProps {
   selectedVariables?: AnalysisVariable[];
@@ -12,6 +16,10 @@ export function SensitivitySummary({
   currentMetric = "NPV", 
   baseValue = 0 
 }: SensitivitySummaryProps) {
+  const [copiedKeyInsights, setCopiedKeyInsights] = useState(false);
+  const [copiedRecommendations, setCopiedRecommendations] = useState(false);
+  const { toast } = useToast();
+
   // Get the top 5 most impactful variables
   const topVariables = [...selectedVariables]
     .sort((a, b) => Math.abs(b.impact) - Math.abs(a.impact))
@@ -38,6 +46,40 @@ export function SensitivitySummary({
     riskColor = "text-amber-500";
     riskWidth = "w-3/5";
   }
+
+  const copyToClipboard = (text: string, setCopied: (value: boolean) => void) => {
+    const fullText = `Sensitivity Analysis\n\n${text}`;
+    navigator.clipboard.writeText(fullText).then(() => {
+      setCopied(true);
+      toast({
+        title: "Copied to clipboard",
+        description: "The content has been copied to your clipboard.",
+      });
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  const getKeyInsightsText = () => {
+    const insights = [];
+    if (topVariables.length > 0) {
+      insights.push(`${topVariables[0].name} has the highest impact on ${currentMetric}`);
+    }
+    insights.push(`${highImpactCount} variables have high sensitivity (>10% impact)`);
+    insights.push(`${selectedVariables.length} total variables analyzed for impact on ${currentMetric}`);
+    return insights.join('\n');
+  };
+
+  const getRecommendationsText = () => {
+    const recommendations = [];
+    if (topVariables.length > 0) {
+      recommendations.push(`Focus on optimizing ${topVariables[0].name}`);
+    }
+    if (topVariables.length > 1) {
+      recommendations.push(`Monitor ${topVariables[1].name} closely`);
+    }
+    recommendations.push('Develop contingency plans for high-impact variables');
+    return recommendations.join('\n');
+  };
 
   // If no variables are selected, show the default content
   if (selectedVariables.length === 0) {
@@ -83,6 +125,17 @@ export function SensitivitySummary({
   return (
     <div className="grid md:grid-cols-2 gap-6 animate-fade-in">
       <DataPanel title="Key Insights" className="border-t-4 border-t-blue-500">
+        <div className="flex justify-between items-center mb-4">
+          <h3 className="font-medium text-lg">Key Insights</h3>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => copyToClipboard(getKeyInsightsText(), setCopiedKeyInsights)}
+            className="h-8 w-8"
+          >
+            {copiedKeyInsights ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+          </Button>
+        </div>
         <ul className="space-y-3 text-sm">
           {topVariables.length > 0 && (
             <li className="flex gap-2">
@@ -102,6 +155,17 @@ export function SensitivitySummary({
       </DataPanel>
       
       <DataPanel title="Recommendations" className="border-t-4 border-t-green-500">
+        <div className="flex justify-between items-center mb-4">
+          <h3 className="font-medium text-lg">Recommendations</h3>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => copyToClipboard(getRecommendationsText(), setCopiedRecommendations)}
+            className="h-8 w-8"
+          >
+            {copiedRecommendations ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+          </Button>
+        </div>
         <ul className="space-y-3 text-sm">
           {topVariables.length > 0 && (
             <li className="flex gap-2">


### PR DESCRIPTION
## Changes\n- Added copy buttons to Key Insights and Recommendations sections\n- Implemented copy functionality with visual feedback\n- Added toast notifications for user feedback\n- Prepend 'Sensitivity Analysis' to copied text\n- Formatted text with line breaks for better readability\n\n## Testing\n- Verify copy button appears in both sections\n- Test copying functionality\n- Check toast notification appears\n- Verify copied text format